### PR TITLE
Add [Out_channel.output_line]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 - Added function `Out_channel.print_s`.
 
+- Added function `Out_channel.output_line`.
+
 ## v0.10
 
 - Enabled `-safe-string`.

--- a/src/out_channel.ml
+++ b/src/out_channel.ml
@@ -49,12 +49,12 @@ let output_buffer = Stdlib.Buffer.output_buffer
 let output_value = Stdlib.output_value
 let newline t = output_string t "\n"
 
-let output_lines t lines =
-  List.iter lines ~f:(fun line ->
-    output_string t line;
-    newline t)
+let output_line t line =
+  output_string t line;
+  newline t
 ;;
 
+let output_lines t lines = List.iter lines ~f:(fun line -> output_line t line)
 let printf = Stdlib.Printf.printf
 let eprintf = Stdlib.Printf.eprintf
 let fprintf = Stdlib.Printf.fprintf

--- a/src/out_channel.mli
+++ b/src/out_channel.mli
@@ -84,6 +84,9 @@ val newline : t -> unit
 (** Outputs a list of lines, each terminated by a newline character *)
 val output_lines : t -> string list -> unit
 
+(** Outputs a single line, terminated by a newline character. *)
+val output_line : t -> string -> unit
+
 (** Formatted printing to an out channel.  This is the same as [Printf.sprintf] except
     that it outputs to [t] instead of returning a string.  Similarly, the function
     arguments corresponding to conversions specifications such as [%a] or [%t] takes [t]


### PR DESCRIPTION
This PR extracts and exposes the inner function that is used as iterator in [Out_channel.output_lines] so one can output a single line at a time to an Out_channel.

I find myself repeating the pattern [Out_channel.output_string + Out_channel.newline] in a few places, so I wanted to propose to expose this function in Out_channel directly.

- Updated changelog